### PR TITLE
Add patient management feature

### DIFF
--- a/src/Application/Domain/Patients/Patient.cs
+++ b/src/Application/Domain/Patients/Patient.cs
@@ -1,0 +1,24 @@
+using VerticalSliceArchitecture.Application.Common;
+
+namespace VerticalSliceArchitecture.Application.Domain.Patients;
+
+public class Patient : AuditableEntity, IHasDomainEvent
+{
+    public int Id { get; set; }
+
+    public Guid UserId { get; set; }
+
+    public string Name { get; set; } = default!;
+
+    public int Age { get; set; }
+
+    public string Phone { get; set; } = default!;
+
+    public string Email { get; set; } = default!;
+
+    public string? Notes { get; set; }
+
+    public DateTime? LastVisit { get; set; }
+
+    public List<DomainEvent> DomainEvents { get; } = [];
+}

--- a/src/Application/Features/Patients/CreatePatient.cs
+++ b/src/Application/Features/Patients/CreatePatient.cs
@@ -1,0 +1,78 @@
+using ErrorOr;
+
+using FluentValidation;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using VerticalSliceArchitecture.Application.Common;
+using VerticalSliceArchitecture.Application.Common.Interfaces;
+using VerticalSliceArchitecture.Application.Domain.Patients;
+using VerticalSliceArchitecture.Application.Infrastructure.Persistence;
+
+namespace VerticalSliceArchitecture.Application.Features.Patients;
+
+public class CreatePatientController : ApiControllerBase
+{
+    [HttpPost("/api/patients")]
+    public async Task<IActionResult> Create(CreatePatientCommand command)
+    {
+        var result = await Mediator.Send(command);
+
+        return result.Match(
+            id => Ok(id),
+            Problem);
+    }
+}
+
+public record CreatePatientCommand(string Name, int Age, string Phone, string Email, string? Notes, DateTime? LastVisit)
+    : IRequest<ErrorOr<int>>;
+
+internal sealed class CreatePatientCommandValidator : AbstractValidator<CreatePatientCommand>
+{
+    public CreatePatientCommandValidator()
+    {
+        RuleFor(c => c.Name)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        RuleFor(c => c.Phone)
+            .NotEmpty()
+            .MaximumLength(50);
+
+        RuleFor(c => c.Email)
+            .NotEmpty()
+            .EmailAddress();
+    }
+}
+
+internal sealed class CreatePatientCommandHandler(
+    ApplicationDbContext context,
+    ICurrentUserService currentUserService)
+    : IRequestHandler<CreatePatientCommand, ErrorOr<int>>
+{
+    private readonly ApplicationDbContext _context = context;
+    private readonly ICurrentUserService _currentUserService = currentUserService;
+
+    public async Task<ErrorOr<int>> Handle(CreatePatientCommand request, CancellationToken cancellationToken)
+    {
+        var userId = Guid.Parse(_currentUserService.UserId!);
+
+        var patient = new Patient
+        {
+            UserId = userId,
+            Name = request.Name,
+            Age = request.Age,
+            Phone = request.Phone,
+            Email = request.Email,
+            Notes = request.Notes,
+            LastVisit = request.LastVisit,
+        };
+
+        _context.Patients.Add(patient);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return patient.Id;
+    }
+}

--- a/src/Application/Features/Patients/DeletePatient.cs
+++ b/src/Application/Features/Patients/DeletePatient.cs
@@ -1,0 +1,52 @@
+using ErrorOr;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using VerticalSliceArchitecture.Application.Common;
+using VerticalSliceArchitecture.Application.Common.Interfaces;
+using VerticalSliceArchitecture.Application.Infrastructure.Persistence;
+
+namespace VerticalSliceArchitecture.Application.Features.Patients;
+
+public class DeletePatientController : ApiControllerBase
+{
+    [HttpDelete("/api/patients/{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var result = await Mediator.Send(new DeletePatientCommand(id));
+
+        return result.Match(_ => NoContent(), Problem);
+    }
+}
+
+public record DeletePatientCommand(int Id) : IRequest<ErrorOr<Success>>;
+
+internal sealed class DeletePatientCommandHandler(
+    ApplicationDbContext context,
+    ICurrentUserService currentUserService)
+    : IRequestHandler<DeletePatientCommand, ErrorOr<Success>>
+{
+    private readonly ApplicationDbContext _context = context;
+    private readonly ICurrentUserService _currentUserService = currentUserService;
+
+    public async Task<ErrorOr<Success>> Handle(DeletePatientCommand request, CancellationToken cancellationToken)
+    {
+        var userId = Guid.Parse(_currentUserService.UserId!);
+
+        var patient = await _context.Patients
+            .FirstOrDefaultAsync(p => p.Id == request.Id && p.UserId == userId, cancellationToken);
+
+        if (patient is null)
+        {
+            return Error.NotFound(description: "Patient not found.");
+        }
+
+        _context.Patients.Remove(patient);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Result.Success;
+    }
+}

--- a/src/Application/Features/Patients/GetPatients.cs
+++ b/src/Application/Features/Patients/GetPatients.cs
@@ -1,0 +1,49 @@
+using ErrorOr;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using VerticalSliceArchitecture.Application.Common;
+using VerticalSliceArchitecture.Application.Common.Interfaces;
+using VerticalSliceArchitecture.Application.Infrastructure.Persistence;
+
+namespace VerticalSliceArchitecture.Application.Features.Patients;
+
+public class GetPatientsController : ApiControllerBase
+{
+    [HttpGet("/api/patients")]
+    public async Task<IActionResult> Get()
+    {
+        var result = await Mediator.Send(new GetPatientsQuery());
+
+        return result.Match(Ok, Problem);
+    }
+}
+
+public record PatientDto(int Id, string Name, int Age, string Phone, string Email, string? Notes, DateTime? LastVisit);
+
+public record GetPatientsQuery : IRequest<ErrorOr<List<PatientDto>>>;
+
+internal sealed class GetPatientsQueryHandler(
+    ApplicationDbContext context,
+    ICurrentUserService currentUserService)
+    : IRequestHandler<GetPatientsQuery, ErrorOr<List<PatientDto>>>
+{
+    private readonly ApplicationDbContext _context = context;
+    private readonly ICurrentUserService _currentUserService = currentUserService;
+
+    public async Task<ErrorOr<List<PatientDto>>> Handle(GetPatientsQuery request, CancellationToken cancellationToken)
+    {
+        var userId = Guid.Parse(_currentUserService.UserId!);
+
+        var patients = await _context.Patients
+            .Where(p => p.UserId == userId)
+            .OrderBy(p => p.Name)
+            .Select(p => new PatientDto(p.Id, p.Name, p.Age, p.Phone, p.Email, p.Notes, p.LastVisit))
+            .ToListAsync(cancellationToken);
+
+        return patients;
+    }
+}

--- a/src/Application/Features/Patients/UpdatePatient.cs
+++ b/src/Application/Features/Patients/UpdatePatient.cs
@@ -1,0 +1,85 @@
+using ErrorOr;
+
+using FluentValidation;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using VerticalSliceArchitecture.Application.Common;
+using VerticalSliceArchitecture.Application.Common.Interfaces;
+using VerticalSliceArchitecture.Application.Infrastructure.Persistence;
+
+namespace VerticalSliceArchitecture.Application.Features.Patients;
+
+public class UpdatePatientController : ApiControllerBase
+{
+    [HttpPut("/api/patients/{id}")]
+    public async Task<IActionResult> Update(int id, UpdatePatientCommand command)
+    {
+        if (id != command.Id)
+        {
+            return Problem(statusCode: StatusCodes.Status400BadRequest, detail: "Not matching ids");
+        }
+
+        var result = await Mediator.Send(command);
+
+        return result.Match(_ => NoContent(), Problem);
+    }
+}
+
+public record UpdatePatientCommand(int Id, string Name, int Age, string Phone, string Email, string? Notes, DateTime? LastVisit)
+    : IRequest<ErrorOr<Success>>;
+
+internal sealed class UpdatePatientCommandValidator : AbstractValidator<UpdatePatientCommand>
+{
+    public UpdatePatientCommandValidator()
+    {
+        RuleFor(c => c.Name)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        RuleFor(c => c.Phone)
+            .NotEmpty()
+            .MaximumLength(50);
+
+        RuleFor(c => c.Email)
+            .NotEmpty()
+            .EmailAddress();
+    }
+}
+
+internal sealed class UpdatePatientCommandHandler(
+    ApplicationDbContext context,
+    ICurrentUserService currentUserService)
+    : IRequestHandler<UpdatePatientCommand, ErrorOr<Success>>
+{
+    private readonly ApplicationDbContext _context = context;
+    private readonly ICurrentUserService _currentUserService = currentUserService;
+
+    public async Task<ErrorOr<Success>> Handle(UpdatePatientCommand request, CancellationToken cancellationToken)
+    {
+        var userId = Guid.Parse(_currentUserService.UserId!);
+
+        var patient = await _context.Patients
+            .FirstOrDefaultAsync(p => p.Id == request.Id && p.UserId == userId, cancellationToken);
+
+        if (patient is null)
+        {
+            return Error.NotFound(description: "Patient not found.");
+        }
+
+        patient.Name = request.Name;
+        patient.Age = request.Age;
+        patient.Phone = request.Phone;
+        patient.Email = request.Email;
+        patient.Notes = request.Notes;
+        patient.LastVisit = request.LastVisit;
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Result.Success;
+    }
+}

--- a/src/Application/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Application/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 using VerticalSliceArchitecture.Application.Common;
 using VerticalSliceArchitecture.Application.Common.Interfaces;
+using VerticalSliceArchitecture.Application.Domain.Patients;
 using VerticalSliceArchitecture.Application.Domain.Todos;
 
 namespace VerticalSliceArchitecture.Application.Infrastructure.Persistence;
@@ -30,6 +31,8 @@ public class ApplicationDbContext : DbContext
     public DbSet<TodoList> TodoLists => Set<TodoList>();
 
     public DbSet<TodoItem> TodoItems => Set<TodoItem>();
+
+    public DbSet<Patient> Patients => Set<Patient>();
 
     public DbSet<Domain.Users.User> Users => Set<Domain.Users.User>();
 

--- a/src/Application/Infrastructure/Persistence/Configurations/PatientConfiguration.cs
+++ b/src/Application/Infrastructure/Persistence/Configurations/PatientConfiguration.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using VerticalSliceArchitecture.Application.Domain.Patients;
+
+namespace VerticalSliceArchitecture.Application.Infrastructure.Persistence.Configurations;
+
+public class PatientConfiguration : IEntityTypeConfiguration<Patient>
+{
+    public void Configure(EntityTypeBuilder<Patient> builder)
+    {
+        builder.Ignore(p => p.DomainEvents);
+
+        builder.Property(p => p.Name)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(p => p.Phone)
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(p => p.Email)
+            .HasMaxLength(256)
+            .IsRequired();
+    }
+}


### PR DESCRIPTION
## Summary
- create Patient entity and EF configuration
- expose CRUD endpoints for Patients
- register DbSet for patients in `ApplicationDbContext`

## Testing
- `dotnet test -p:TreatWarningsAsErrors=false`

------
https://chatgpt.com/codex/tasks/task_e_687bfc27c1f883208316e24f80a4d384