### PR TITLE
Add refresh token functionality

### DIFF
--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -14,6 +14,6 @@
     "Key": "bF6!vQk$eU@9sLx2W#rA7gZpH3nTcY1d",
     "Issuer": "FidiVsApi",
     "Audience": "FidiVsClient",
-    "ExpiryMinutes": 60
+    "ExpiryMinutes": 15
   }
 }

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -12,7 +12,7 @@
     "Key": "bF6!vQk$eU@9sLx2W#rA7gZpH3nTcY1d",
     "Issuer": "FidiVsApi",
     "Audience": "FidiVsClient",
-    "ExpiryMinutes": 60
+    "ExpiryMinutes": 15
   },
   "AllowedHosts": "*"
 }

--- a/src/Application/Domain/Users/User.cs
+++ b/src/Application/Domain/Users/User.cs
@@ -8,4 +8,6 @@ public class User : AuditableEntity
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
     public string PasswordHash { get; set; } = string.Empty;
+    public string? RefreshToken { get; set; }
+    public DateTime? RefreshTokenExpires { get; set; }
 }

--- a/src/Application/Features/Auth/RefreshToken.cs
+++ b/src/Application/Features/Auth/RefreshToken.cs
@@ -1,0 +1,61 @@
+using System.Security.Cryptography;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+using VerticalSliceArchitecture.Application.Common;
+using VerticalSliceArchitecture.Application.Common.Interfaces;
+using VerticalSliceArchitecture.Application.Common.Models;
+using VerticalSliceArchitecture.Application.Infrastructure.Authentication;
+using VerticalSliceArchitecture.Application.Infrastructure.Persistence;
+
+namespace VerticalSliceArchitecture.Application.Features.Auth;
+
+[Tags("Auth")]
+public class RefreshTokenController : ApiControllerBase
+{
+    [HttpPost("/api/refresh-token")]
+    public async Task<IActionResult> Refresh(RefreshTokenCommand command)
+    {
+        return ApiResult(await Mediator.Send(command));
+    }
+}
+
+public record RefreshTokenCommand(string RefreshToken) : IRequest<ApiResponse<LoginUserResponse>>;
+
+internal sealed class RefreshTokenCommandHandler(
+    ApplicationDbContext context,
+    IJwtTokenGenerator tokenGenerator,
+    IOptions<JwtSettings> options) : IRequestHandler<RefreshTokenCommand, ApiResponse<LoginUserResponse>>
+{
+    public async Task<ApiResponse<LoginUserResponse>> Handle(RefreshTokenCommand request, CancellationToken cancellationToken)
+    {
+        var user = await context.Users.FirstOrDefaultAsync(u => u.RefreshToken == request.RefreshToken, cancellationToken);
+        if (user is null)
+        {
+            throw new AppException("Geçersiz refresh token.");
+        }
+
+        if (user.RefreshTokenExpires is null || user.RefreshTokenExpires <= DateTime.UtcNow)
+        {
+            throw new AppException("Refresh token süresi dolmuş.");
+        }
+
+        var newRefreshToken = Convert.ToBase64String(RandomNumberGenerator.GetBytes(64));
+        user.RefreshToken = newRefreshToken;
+        user.RefreshTokenExpires = DateTime.UtcNow.AddDays(7);
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var userDto = new UserDto(user.Email, user.FirstName, user.LastName);
+
+        var accessToken = tokenGenerator.GenerateToken(user);
+        var expiresIn = options.Value.ExpiryMinutes * 60;
+
+        return ApiResponse<LoginUserResponse>.Success(new LoginUserResponse(accessToken, newRefreshToken, expiresIn, userDto));
+    }
+}

--- a/src/Application/Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/src/Application/Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
 using VerticalSliceArchitecture.Application.Domain.Users;
 
 namespace VerticalSliceArchitecture.Application.Infrastructure.Persistence.Configurations;
@@ -22,5 +23,9 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
 
         builder.Property(u => u.LastName)
             .IsRequired();
+
+        builder.Property(u => u.RefreshToken);
+
+        builder.Property(u => u.RefreshTokenExpires);
     }
 }

--- a/src/Application/Infrastructure/Persistence/Migrations/20250727113655_AddRefreshToken.Designer.cs
+++ b/src/Application/Infrastructure/Persistence/Migrations/20250727113655_AddRefreshToken.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VerticalSliceArchitecture.Application.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using VerticalSliceArchitecture.Application.Infrastructure.Persistence;
 namespace VerticalSliceArchitecture.Application.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250727113655_AddRefreshToken")]
+    partial class AddRefreshToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Application/Infrastructure/Persistence/Migrations/20250727113655_AddRefreshToken.cs
+++ b/src/Application/Infrastructure/Persistence/Migrations/20250727113655_AddRefreshToken.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VerticalSliceArchitecture.Application.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RefreshToken",
+                schema: "identity",
+                table: "users",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "RefreshTokenExpires",
+                schema: "identity",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RefreshToken",
+                schema: "identity",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "RefreshTokenExpires",
+                schema: "identity",
+                table: "users");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add refresh token fields in User entity
- generate refresh tokens on login
- create refresh-token endpoint to exchange expired token
- store refresh tokens in the database via new migration
- set JWT expiry to 15 minutes

## Testing
- `dotnet test`
- `dotnet test tests/Application.IntegrationTests/Application.IntegrationTests.csproj` *(fails: NU1008 central package version management)*

------
https://chatgpt.com/codex/tasks/task_e_68860e806cb08320a61497b09ffdf6ff